### PR TITLE
Add manage link to user table

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -35,7 +35,8 @@ rules:
   no-empty-rulesets: 2
   no-extends: 0
   no-ids: 2
-  no-important: 2
+  # nessesary to override styles coming from NHSUK-frontend
+  no-important: 0
   no-invalid-hex: 2
   no-mergeable-selectors: 2
   no-misspelled-properties: 2

--- a/app/pages/adduser/__snapshots__/template.test.js.snap
+++ b/app/pages/adduser/__snapshots__/template.test.js.snap
@@ -1,0 +1,411 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`organisations add user page the page should render 1`] = `
+"<main class=\\"nhsuk-main-wrapper\\" id=\\"maincontent\\" data-test-id=\\"main-content\\">
+        
+  <div class=\\"nhsuk-width-container\\" data-test-id=\\"add-user-page\\">
+    <div data-test-id=\\"go-back-link\\">
+      <div class=\\"nhsuk-back-link\\">
+  <a class=\\"nhsuk-back-link__link\\" href=\\"/organisations/org1\\">
+  <svg class=\\"nhsuk-icon nhsuk-icon__chevron-left\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\">
+    <path d=\\"M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z\\"></path>
+  </svg>
+  Go back</a>
+</div>
+
+    </div>
+    <div class=\\"nhsuk-grid-row\\">
+      <div class=\\"nhsuk-grid-column-two-thirds\\">
+        
+
+        <h1 data-test-id=\\"add-user-page-title\\" class=\\"nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3\\">Add new user</h1>
+        <p data-test-id=\\"add-user-page-description\\" class=\\"nhsuk-heading-l nhsuk-u-font-size-24 nhsuk-u-margin-bottom-6\\">Provide the following information to make a new user account.</p>
+
+        <h2 data-test-id=\\"org-name-subheading\\" class=\\"nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\">Organisation name</h2>
+        
+  
+
+
+        <form method=\\"post\\">
+          <input type=\\"hidden\\" name=\\"_csrf\\" value=\\"\\">
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-firstName\\">
+    
+      <div data-test-id=\\"text-field-input\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"firstName\\">
+    First name
+  </label>
+  <input class=\\"nhsuk-input\\" id=\\"firstName\\" name=\\"firstName\\" type=\\"text\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-lastName\\">
+    
+      <div data-test-id=\\"text-field-input\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"lastName\\">
+    Last name
+  </label>
+  <input class=\\"nhsuk-input\\" id=\\"lastName\\" name=\\"lastName\\" type=\\"text\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-phoneNumber\\">
+    
+      <div data-test-id=\\"text-field-input\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"phoneNumber\\">
+    Telephone number
+  </label>
+  <input class=\\"nhsuk-input\\" id=\\"phoneNumber\\" name=\\"phoneNumber\\" type=\\"text\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-emailAddress\\">
+    
+      <div data-test-id=\\"text-field-input\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"emailAddress\\">
+    Email address
+  </label>
+  <input class=\\"nhsuk-input\\" id=\\"emailAddress\\" name=\\"emailAddress\\" type=\\"text\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+
+          <div data-test-id=\\"add-user-button\\" class=\\"nhsuk-u-margin-top-9\\">
+            
+
+
+  
+    
+  
+
+
+
+
+<button class=\\"nhsuk-button nhsuk-u-margin-bottom-9\\" type=\\"submit\\">
+  Add user
+</button>
+
+
+
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+      </main>"
+`;
+
+exports[`organisations add user page the page should render with errors 1`] = `
+"<main class=\\"nhsuk-main-wrapper\\" id=\\"maincontent\\" data-test-id=\\"main-content\\">
+        
+  <div class=\\"nhsuk-width-container\\" data-test-id=\\"add-user-page\\">
+    <div data-test-id=\\"go-back-link\\">
+      <div class=\\"nhsuk-back-link\\">
+  <a class=\\"nhsuk-back-link__link\\" href=\\"/organisations/org1\\">
+  <svg class=\\"nhsuk-icon nhsuk-icon__chevron-left\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\">
+    <path d=\\"M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z\\"></path>
+  </svg>
+  Go back</a>
+</div>
+
+    </div>
+    <div class=\\"nhsuk-grid-row\\">
+      <div class=\\"nhsuk-grid-column-two-thirds\\">
+        
+          
+  <div data-test-id=\\"error-summary\\">
+    <div class=\\"nhsuk-error-summary\\" aria-labelledby=\\"error-summary-title\\" role=\\"alert\\" tabindex=\\"-1\\">
+  <h2 class=\\"nhsuk-error-summary__title\\" id=\\"error-summary-title\\">
+    There is a problem
+  </h2>
+  <div class=\\"nhsuk-error-summary__body\\"><ul class=\\"nhsuk-list nhsuk-error-summary__list\\">
+      <li>
+        <a href=\\"#firstname\\">First name is required</a>
+      </li>
+      <li>
+        <a href=\\"#firstname\\">First name is too long</a>
+      </li>
+      <li>
+        <a href=\\"#lastname\\">Last name is required</a>
+      </li>
+      <li>
+        <a href=\\"#lastname\\">Last name is too long</a>
+      </li>
+      <li>
+        <a href=\\"#emailaddress\\">Email is required</a>
+      </li>
+      <li>
+        <a href=\\"#emailaddress\\">Email address is too long</a>
+      </li>
+      <li>
+        <a href=\\"#emailaddress\\">Email address already exists</a>
+      </li>
+      <li>
+        <a href=\\"#phonenumber\\">Telephone number is required</a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+  </div>
+
+        
+
+        <h1 data-test-id=\\"add-user-page-title\\" class=\\"nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3\\">Add new user</h1>
+        <p data-test-id=\\"add-user-page-description\\" class=\\"nhsuk-heading-l nhsuk-u-font-size-24 nhsuk-u-margin-bottom-6\\">Provide the following information to make a new user account.</p>
+
+        <h2 data-test-id=\\"org-name-subheading\\" class=\\"nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\">Organisation name</h2>
+        
+  
+
+
+        <form method=\\"post\\">
+          <input type=\\"hidden\\" name=\\"_csrf\\" value=\\"\\">
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-firstName\\">
+    
+      <div data-test-id=\\"text-field-input-error\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-form-group--error nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"firstName\\">
+    First name
+  </label>
+  <span class=\\"nhsuk-error-message\\" id=\\"firstName-error\\">
+    <span class=\\"nhsuk-u-visually-hidden\\">Error:</span> 
+  </span>
+  <input class=\\"nhsuk-input nhsuk-input--error\\" id=\\"firstName\\" name=\\"firstName\\" type=\\"text\\" aria-describedby=\\"firstName-error\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-lastName\\">
+    
+      <div data-test-id=\\"text-field-input-error\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-form-group--error nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"lastName\\">
+    Last name
+  </label>
+  <span class=\\"nhsuk-error-message\\" id=\\"lastName-error\\">
+    <span class=\\"nhsuk-u-visually-hidden\\">Error:</span> 
+  </span>
+  <input class=\\"nhsuk-input nhsuk-input--error\\" id=\\"lastName\\" name=\\"lastName\\" type=\\"text\\" aria-describedby=\\"lastName-error\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-phoneNumber\\">
+    
+      <div data-test-id=\\"text-field-input-error\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-form-group--error nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"phoneNumber\\">
+    Telephone number
+  </label>
+  <span class=\\"nhsuk-error-message\\" id=\\"phoneNumber-error\\">
+    <span class=\\"nhsuk-u-visually-hidden\\">Error:</span> 
+  </span>
+  <input class=\\"nhsuk-input nhsuk-input--error\\" id=\\"phoneNumber\\" name=\\"phoneNumber\\" type=\\"text\\" aria-describedby=\\"phoneNumber-error\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+            <div class=\\"nhsuk-u-margin-bottom-4\\">
+              
+  
+    
+  
+
+  
+
+  <div data-test-id=\\"question-emailAddress\\">
+    
+      <div data-test-id=\\"text-field-input-error\\">
+        
+
+<div class=\\"nhsuk-form-group nhsuk-form-group--error nhsuk-u-margin-bottom-2\\">
+  <label class=\\"nhsuk-label nhsuk-u-font-size-24 nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2\\" for=\\"emailAddress\\">
+    Email address
+  </label>
+  <span class=\\"nhsuk-error-message\\" id=\\"emailAddress-error\\">
+    <span class=\\"nhsuk-u-visually-hidden\\">Error:</span> 
+  </span>
+  <input class=\\"nhsuk-input nhsuk-input--error\\" id=\\"emailAddress\\" name=\\"emailAddress\\" type=\\"text\\" aria-describedby=\\"emailAddress-error\\">
+</div>
+
+      </div>
+    
+    <div data-test-id=\\"text-field-footer\\">
+      <span class=\\"nhsuk-label bc-t-font-color--grey-1 nhsuk-u-font-size-16\\">
+        
+      </span>
+    </div>
+  </div>
+
+            </div>
+          
+
+          <div data-test-id=\\"add-user-button\\" class=\\"nhsuk-u-margin-top-9\\">
+            
+
+
+  
+    
+  
+
+
+
+
+<button class=\\"nhsuk-button nhsuk-u-margin-bottom-9\\" type=\\"submit\\">
+  Add user
+</button>
+
+
+
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+      </main>"
+`;

--- a/app/pages/adduser/template.njk
+++ b/app/pages/adduser/template.njk
@@ -10,7 +10,7 @@
     <div data-test-id="go-back-link">
       {{ backLink({
         "href": backLinkHref,
-        "text": "Back"
+        "text": "Go back"
       }) }}
     </div>
     <div class="nhsuk-grid-row">
@@ -22,9 +22,9 @@
         {% endif %}
 
         <h1 data-test-id="add-user-page-title" class="nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3">{{ title }}</h1>
-        <h2 data-test-id="add-user-page-description" class="nhsuk-u-font-size-24 nhsuk-u-margin-bottom-6">{{ description }}</h2>
+        <p data-test-id="add-user-page-description" class="nhsuk-heading-l nhsuk-u-font-size-24 nhsuk-u-margin-bottom-6">{{ description }}</p>
 
-        <h3 data-test-id="org-name-subheading" class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2">{{ orgNameSubheading }}</h3>
+        <h2 data-test-id="org-name-subheading" class="nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2">{{ orgNameSubheading }}</h2>
         {{ viewDataText({
           dataTestId: "org-name",
           classes: "nhsuk-u-margin-bottom-9",

--- a/app/pages/adduser/template.test.js
+++ b/app/pages/adduser/template.test.js
@@ -1,4 +1,4 @@
-import { componentTester } from '../../test-utils/componentTester';
+import { componentTester, snapshotTest } from '../../test-utils/componentTester';
 import context from './manifest.json';
 
 context.backLinkHref = '/organisations/org1';
@@ -50,11 +50,25 @@ const contextWithErrors = {
 };
 
 describe('organisations add user page', () => {
+  it('the page should render', componentTester(setup, (harness) => {
+    harness.request(context, ($) => {
+      const snapshot = snapshotTest($, '[data-test-id="main-content"]');
+      expect(snapshot).toMatchSnapshot();
+    });
+  }));
+
+  it('the page should render with errors', componentTester(setup, (harness) => {
+    harness.request(contextWithErrors, ($) => {
+      const snapshot = snapshotTest($, '[data-test-id="main-content"]');
+      expect(snapshot).toMatchSnapshot();
+    });
+  }));
+
   it('should render a backLink', componentTester(setup, (harness) => {
     harness.request(context, ($) => {
       const backLink = $('[data-test-id="go-back-link"]');
       expect(backLink.length).toEqual(1);
-      expect(backLink.text().trim()).toEqual('Back');
+      expect(backLink.text().trim()).toEqual('Go back');
       expect($(backLink).find('a').attr('href')).toEqual('/organisations/org1');
     });
   }));
@@ -90,7 +104,7 @@ describe('organisations add user page', () => {
 
   it('should render a organisation name subheading', componentTester(setup, (harness) => {
     harness.request(context, ($) => {
-      const subheading = $('h3[data-test-id="org-name-subheading"]');
+      const subheading = $('h2[data-test-id="org-name-subheading"]');
       expect(subheading.length).toEqual(1);
       expect(subheading.text().trim()).toEqual(context.orgNameSubheading);
     });

--- a/app/pages/adduser/ui.test.js
+++ b/app/pages/adduser/ui.test.js
@@ -99,7 +99,7 @@ test('should render the description', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);
 
-  const description = Selector('h2[data-test-id="add-user-page-description"]');
+  const description = Selector('p[data-test-id="add-user-page-description"]');
 
   await t
     .expect(description.exists).ok()
@@ -110,7 +110,7 @@ test('should render organisation name subheading', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);
 
-  const orgDetailsSubheading = Selector('h3[data-test-id="org-name-subheading"]');
+  const orgDetailsSubheading = Selector('h2[data-test-id="org-name-subheading"]');
 
   await t
     .expect(orgDetailsSubheading.exists).ok()

--- a/app/pages/dashboard/__snapshots__/template.test.js.snap
+++ b/app/pages/dashboard/__snapshots__/template.test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`organisations dashboard page the page should render 1`] = `
+"<main class=\\"nhsuk-main-wrapper\\" id=\\"maincontent\\" data-test-id=\\"main-content\\">
+        
+  <div class=\\"nhsuk-width-container\\" data-test-id=\\"organisations\\">
+    <div data-test-id=\\"go-back-link\\">
+      <div class=\\"nhsuk-back-link\\">
+  <a class=\\"nhsuk-back-link__link\\" href=\\"http://localhost:3000/re-login\\">
+  <svg class=\\"nhsuk-icon nhsuk-icon__chevron-left\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\">
+    <path d=\\"M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z\\"></path>
+  </svg>
+  Go back to previous page</a>
+</div>
+
+    </div>
+    <h1 data-test-id=\\"org-dashboard-title\\" class=\\"nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3\\">Manage organisations and users</h1>
+    <p data-test-id=\\"org-dashboard-description\\" class=\\"nhsuk-heading-l nhsuk-u-font-size-22 nhsuk-u-margin-bottom-9\\">Edit existing account information or add new users to an organisation.</p>
+
+    <div data-test-id=\\"add-org-button\\">
+      
+
+
+  
+    
+  
+
+
+
+
+<a class=\\"nhsuk-button nhsuk-u-margin-bottom-9\\" href=\\"/organisations/find\\" draggable=\\"false\\">
+  Add an organisation
+</a>
+
+
+
+    </div>
+
+    <div data-test-id=\\"org-table\\" class=\\"nhsuk-u-font-size-19\\">
+      
+  <table data-test-id=\\"table\\" class=\\"\\" style=\\"page-break-inside:auto\\">
+    
+    
+      <thead data-test-id=\\"table-headings\\" style=\\"display:table-header-group;\\">
+        
+          <tr><th data-test-id=\\"column-heading-0\\" class=\\"nhsuk-u-padding-bottom-0 \\" style=\\"width:\\">
+            <div data-test-id=\\"column-heading-0-data\\" class=\\"nhsuk-u-font-weight-bold\\">Organisation name</div>
+            
+            
+          </th>
+        
+          <th data-test-id=\\"column-heading-1\\" class=\\"nhsuk-u-padding-bottom-0 \\" style=\\"width:\\">
+            <div data-test-id=\\"column-heading-1-data\\" class=\\"nhsuk-u-font-weight-bold\\">ODS code</div>
+            
+            
+          </th>
+        
+      </tr></thead>
+    
+
+    <tbody>
+    
+      <tr data-test-id=\\"table-row-0\\" style=\\"page-break-inside:avoid; page-break-after:auto\\">
+        
+          
+          <td class=\\"nhsuk-u-padding-bottom-0\\" style=\\"border-bottom-style: solid\\">
+
+            
+              <a data-test-id=\\"org-name-org1\\" href=\\"/organisations/org1\\">A lovely organisation</a>
+            
+
+            
+          </td>
+        
+          
+          <td class=\\"nhsuk-u-padding-bottom-0\\" style=\\"border-bottom-style: solid\\">
+
+            
+              
+  
+    
+    <div data-test-id=\\"ods-code-org1\\" class=\\"bc-c-data-text \\">ODS1</div>
+  
+
+            
+
+            
+          </td>
+        
+      </tr>
+    
+      <tr data-test-id=\\"table-row-1\\" style=\\"page-break-inside:avoid; page-break-after:auto\\">
+        
+          
+          <td class=\\"nhsuk-u-padding-bottom-0\\" style=\\"border-bottom-style: solid\\">
+
+            
+              <a data-test-id=\\"org-name-org2\\" href=\\"/organisations/org2\\">Another lovely organisation</a>
+            
+
+            
+          </td>
+        
+          
+          <td class=\\"nhsuk-u-padding-bottom-0\\" style=\\"border-bottom-style: solid\\">
+
+            
+              
+  
+    
+    <div data-test-id=\\"ods-code-org2\\" class=\\"bc-c-data-text \\">ODS2</div>
+  
+
+            
+
+            
+          </td>
+        
+      </tr>
+    
+    </tbody>
+    
+  </table>
+
+    </div>
+  </div>
+
+      </main>"
+`;

--- a/app/pages/dashboard/template.njk
+++ b/app/pages/dashboard/template.njk
@@ -12,7 +12,7 @@
       }) }}
     </div>
     <h1 data-test-id="org-dashboard-title" class="nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3">{{ title }}</h1>
-    <h2 data-test-id="org-dashboard-description" class="nhsuk-u-font-size-22 nhsuk-u-margin-bottom-9">{{ description }}</h2>
+    <p data-test-id="org-dashboard-description" class="nhsuk-heading-l nhsuk-u-font-size-22 nhsuk-u-margin-bottom-9">{{ description }}</p>
 
     <div data-test-id="add-org-button">
       {{ button({

--- a/app/pages/dashboard/template.test.js
+++ b/app/pages/dashboard/template.test.js
@@ -1,4 +1,4 @@
-import { componentTester } from '../../test-utils/componentTester';
+import { componentTester, snapshotTest } from '../../test-utils/componentTester';
 import content from './manifest.json';
 import { publicBrowseBaseUrl } from '../../config';
 
@@ -34,6 +34,13 @@ const context = {
 };
 
 describe('organisations dashboard page', () => {
+  it('the page should render', componentTester(setup, (harness) => {
+    harness.request(context, ($) => {
+      const snapshot = snapshotTest($, '[data-test-id="main-content"]');
+      expect(snapshot).toMatchSnapshot();
+    });
+  }));
+
   it('should render a backLink to public browse', componentTester(setup, (harness) => {
     harness.request(context, ($) => {
       const homepageBackLink = $('[data-test-id="go-back-link"]');

--- a/app/pages/dashboard/ui.test.js
+++ b/app/pages/dashboard/ui.test.js
@@ -114,7 +114,7 @@ test('should render the description', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);
 
-  const description = Selector('h2[data-test-id="org-dashboard-description"]');
+  const description = Selector('p[data-test-id="org-dashboard-description"]');
 
   await t
     .expect(description.exists).ok()

--- a/app/pages/editorg/__snapshots__/template.test.js.snap
+++ b/app/pages/editorg/__snapshots__/template.test.js.snap
@@ -10,13 +10,17 @@ exports[`editorg page the page should render 1`] = `
   <svg class=\\"nhsuk-icon nhsuk-icon__chevron-left\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\">
     <path d=\\"M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z\\"></path>
   </svg>
-  Back</a>
+  Go back</a>
 </div>
 
     </div>
   
-    <h1 data-test-id=\\"edit-org-page-title\\" class=\\"nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3\\">Edit Greater Manchester CCG</h1>
-    <p data-test-id=\\"edit-org-page-description\\" class=\\"nhsuk-heading-l nhsuk-u-font-size-22 nhsuk-u-margin-bottom-9\\">Change the Organisation End User Agreement status for this organisation.</p>
+    <div class=\\"nhsuk-grid-row\\">
+      <div class=\\"nhsuk-grid-column-two-thirds\\">
+        <h1 data-test-id=\\"edit-org-page-title\\" class=\\"nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3\\">Edit Greater Manchester CCG</h1>
+        <p data-test-id=\\"edit-org-page-description\\" class=\\"nhsuk-heading-l nhsuk-u-font-size-22 nhsuk-u-margin-bottom-9\\">Change the Organisation End User Agreement status for this organisation.</p>
+      </div>
+    </div>
 
     <dl class=\\"nhsuk-summary-list nhsuk-u-padding-margin-5\\">
       <div class=\\"nhsuk-summary-list__row\\">

--- a/app/pages/editorg/template.njk
+++ b/app/pages/editorg/template.njk
@@ -8,12 +8,16 @@
     <div data-test-id="go-back-link">
       {{ backLink({
         "href": backLinkHref,
-        "text": "Back"
+        "text": "Go back"
       }) }}
     </div>
   
-    <h1 data-test-id="edit-org-page-title" class="nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3">Edit {{ organisationName }}</h1>
-    <p data-test-id="edit-org-page-description" class="nhsuk-heading-l nhsuk-u-font-size-22 nhsuk-u-margin-bottom-9">Change the Organisation End User Agreement status for this organisation.</p>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h1 data-test-id="edit-org-page-title" class="nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3">Edit {{ organisationName }}</h1>
+        <p data-test-id="edit-org-page-description" class="nhsuk-heading-l nhsuk-u-font-size-22 nhsuk-u-margin-bottom-9">Change the Organisation End User Agreement status for this organisation.</p>
+      </div>
+    </div>
 
     <dl class="nhsuk-summary-list nhsuk-u-padding-margin-5">
       <div class="nhsuk-summary-list__row">

--- a/app/pages/organisation/__snapshots__/template.test.js.snap
+++ b/app/pages/organisation/__snapshots__/template.test.js.snap
@@ -15,10 +15,13 @@ exports[`organisations dashboard page the page should render 1`] = `
 
     </div>
   
-    <h1 data-test-id=\\"org-page-title\\" class=\\"nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3\\">Greater Manchester CCG</h1>
-    <p data-test-id=\\"org-page-description\\" class=\\"nhsuk-heading-l nhsuk-u-font-size-22\\">These are the details for the organisation and its users.</p>
-
-    <h2 data-test-id=\\"organisation-details-subheading\\">Organisation details</h2>
+    <div class=\\"nhsuk-grid-row\\">
+      <div class=\\"nhsuk-grid-column-two-thirds\\">
+        <h1 data-test-id=\\"org-page-title\\" class=\\"nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3\\">Greater Manchester CCG</h1>
+        <p data-test-id=\\"org-page-description\\" class=\\"nhsuk-heading-l nhsuk-u-font-size-22\\">These are the details for the organisation and its users.</p>
+        <h2 data-test-id=\\"organisation-details-subheading\\">Organisation details</h2>
+      </div>
+    </div>
 
     <dl class=\\"nhsuk-summary-list nhsuk-u-padding-margin-5\\">
       <div class=\\"nhsuk-summary-list__row\\">
@@ -76,8 +79,12 @@ exports[`organisations dashboard page the page should render 1`] = `
       </div>
     </dl>
   
-    <h2>User accounts</h2>
-    <p>These are the user accounts for Greater Manchester CCG.</p>
+    <div class=\\"nhsuk-grid-row\\">
+      <div class=\\"nhsuk-grid-column-two-thirds\\">
+        <h2>User accounts</h2>
+        <p>These are the user accounts for Greater Manchester CCG.</p>
+      </div>
+    </div>
 
     <div data-test-id=\\"add-user-button\\">
       <div class=\\"nhsuk-action-link\\">
@@ -92,7 +99,7 @@ exports[`organisations dashboard page the page should render 1`] = `
 
     </div>
 
-    <div class=\\"nhsuk-u-font-size-19\\">
+    <div data-test-id=\\"users-table\\" class=\\"nhsuk-u-font-size-19 even-table\\">
       
   <table data-test-id=\\"table\\" class=\\"\\" style=\\"page-break-inside:auto\\">
     
@@ -119,6 +126,12 @@ exports[`organisations dashboard page the page should render 1`] = `
         
           <th data-test-id=\\"column-heading-3\\" class=\\"nhsuk-u-padding-bottom-0 \\" style=\\"width:\\">
             <div data-test-id=\\"column-heading-3-data\\" class=\\"nhsuk-u-font-weight-bold\\"></div>
+            
+            
+          </th>
+        
+          <th data-test-id=\\"column-heading-4\\" class=\\"nhsuk-u-padding-bottom-0 \\" style=\\"width:\\">
+            <div data-test-id=\\"column-heading-4-data\\" class=\\"nhsuk-u-font-weight-bold\\"></div>
             
             
           </th>
@@ -232,7 +245,7 @@ exports[`organisations dashboard page the page should render 1`] = `
             
               <div>
                 
-  <div data-test-id=\\"account-disabled-tag-user2\\" class=\\"bc-c-tag nhsuk-u-font-weight-bold bc-c-tag-outline nhsuk-u-font-size-16\\">ACCOUNT DISABLED</div>
+  <div data-test-id=\\"account-disabled-tag-user2\\" class=\\"bc-c-tag nhsuk-u-font-weight-bold bc-c-tag-outline nhsuk-u-font-size-14\\">ACCOUNT DISABLED</div>
 
               </div>
             
@@ -248,8 +261,12 @@ exports[`organisations dashboard page the page should render 1`] = `
 
     </div>
 
-    <h2>Related organisations</h2>
-    <p>These are the organisations Greater Manchester CCG can create orders for.</p>
+    <div class=\\"nhsuk-grid-row\\">
+      <div class=\\"nhsuk-grid-column-two-thirds\\">
+        <h2>Related organisations</h2>
+        <p>These are the organisations Greater Manchester CCG can create orders for.</p>
+      </div>
+    </div>
 
     <div data-test-id=\\"add-organisation-button\\">
       <div class=\\"nhsuk-action-link\\">
@@ -264,7 +281,7 @@ exports[`organisations dashboard page the page should render 1`] = `
 
     </div>
 
-    <div id=\\"related-org-table\\" class=\\"nhsuk-u-font-size-19\\">
+    <div data-test-id=\\"related-org-table\\" id=\\"related-org-table\\" class=\\"nhsuk-u-font-size-19 even-table\\">
       
   <table data-test-id=\\"table\\" class=\\"\\" style=\\"page-break-inside:auto\\">
     

--- a/app/pages/organisation/contextCreator.js
+++ b/app/pages/organisation/contextCreator.js
@@ -12,7 +12,6 @@ export const getContext = ({ organisation }) => ({
   users: organisation && organisation.users ? organisation.users.map((row) => [
     {
       data: `${(`${row.firstName ? row.firstName : ''} ${row.lastName ? row.lastName : ''}`).trim()}` || '',
-      href: `${baseUrl}/organisations/${organisation.organisationId}/${row.userId}`,
       dataTestId: `user-name-${row.userId}`,
     },
     {
@@ -26,9 +25,14 @@ export const getContext = ({ organisation }) => ({
     {
       tag: row.isDisabled ? {
         dataTestId: `account-disabled-tag-${row.userId}`,
-        classes: 'bc-c-tag-outline nhsuk-u-font-size-16',
+        classes: 'bc-c-tag-outline nhsuk-u-font-size-14',
         text: 'ACCOUNT DISABLED',
       } : false,
+    },
+    {
+      data: 'Manage',
+      href: `${baseUrl}/organisations/${organisation.organisationId}/${row.userId}`,
+      dataTestId: `user-manage-${row.userId}`,
     },
   ]) : [],
   backLinkHref: `${baseUrl}/organisations`,

--- a/app/pages/organisation/contextCreator.test.js
+++ b/app/pages/organisation/contextCreator.test.js
@@ -75,17 +75,19 @@ describe('getOrganisationContext', () => {
   it('should transform user data into correct format if all data provided', () => {
     const { users } = getContext({ organisation: mockData });
     expect(users[0][0].data).toEqual(`${mockData.users[0].firstName} ${mockData.users[0].lastName}`);
-    expect(users[0][0].href).toEqual(`${baseUrl}/organisations/${mockData.organisationId}/${mockData.users[0].userId}`);
     expect(users[0][1].data).toEqual(mockData.users[0].phoneNumber);
     expect(users[0][2].data).toEqual(mockData.users[0].emailAddress);
     expect(users[0][3].tag).toEqual(false);
+    expect(users[0][4].data).toEqual('Manage');
+    expect(users[0][4].href).toEqual(`${baseUrl}/organisations/${mockData.organisationId}/${mockData.users[0].userId}`);
     expect(users[1][0].data).toEqual(`${mockData.users[1].firstName} ${mockData.users[1].lastName}`);
-    expect(users[1][0].href).toEqual(`${baseUrl}/organisations/${mockData.organisationId}/${mockData.users[1].userId}`);
     expect(users[1][1].data).toEqual(mockData.users[1].phoneNumber);
     expect(users[1][2].data).toEqual(mockData.users[1].emailAddress);
     expect(users[1][3].tag.dataTestId).toEqual(`account-disabled-tag-${mockData.users[1].userId}`);
-    expect(users[1][3].tag.classes).toEqual('bc-c-tag-outline nhsuk-u-font-size-16');
+    expect(users[1][3].tag.classes).toEqual('bc-c-tag-outline nhsuk-u-font-size-14');
     expect(users[1][3].tag.text).toEqual('ACCOUNT DISABLED');
+    expect(users[1][4].data).toEqual('Manage');
+    expect(users[1][4].href).toEqual(`${baseUrl}/organisations/${mockData.organisationId}/${mockData.users[1].userId}`);
   });
 
   it('should transform user data into correct format if data provided has missing fields', () => {
@@ -105,15 +107,17 @@ describe('getOrganisationContext', () => {
 
     const { users } = getContext({ organisation: modifiedMockData });
     expect(users[0][0].data).toEqual('');
-    expect(users[0][0].href).toEqual(`${baseUrl}/organisations/${modifiedMockData.organisationId}/${modifiedMockData.users[0].userId}`);
     expect(users[0][1].data).toEqual('');
     expect(users[0][2].data).toEqual(mockData.users[0].emailAddress);
     expect(users[0][3].tag).toEqual(false);
+    expect(users[0][4].data).toEqual('Manage');
+    expect(users[0][4].href).toEqual(`${baseUrl}/organisations/${modifiedMockData.organisationId}/${modifiedMockData.users[0].userId}`);
     expect(users[1][0].data).toEqual(`${mockData.users[1].firstName} ${mockData.users[1].lastName}`);
-    expect(users[1][0].href).toEqual(`${baseUrl}/organisations/${modifiedMockData.organisationId}/${modifiedMockData.users[1].userId}`);
     expect(users[1][1].data).toEqual(mockData.users[1].phoneNumber);
     expect(users[1][2].data).toEqual('');
     expect(users[1][3].tag).toEqual(false);
+    expect(users[0][4].data).toEqual('Manage');
+    expect(users[1][4].href).toEqual(`${baseUrl}/organisations/${modifiedMockData.organisationId}/${modifiedMockData.users[1].userId}`);
   });
 
   it('should construct backLinkHref from the data provided', () => {

--- a/app/pages/organisation/proxy/remove/__snapshots__/template.test.js.snap
+++ b/app/pages/organisation/proxy/remove/__snapshots__/template.test.js.snap
@@ -10,7 +10,7 @@ exports[`add proxy for organisation the page should render 1`] = `
   <svg class=\\"nhsuk-icon nhsuk-icon__chevron-left\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\">
     <path d=\\"M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z\\"></path>
   </svg>
-  Back</a>
+  Go back</a>
 </div>
 
     </div>

--- a/app/pages/organisation/proxy/remove/template.njk
+++ b/app/pages/organisation/proxy/remove/template.njk
@@ -10,7 +10,7 @@
     <div data-test-id="go-back-link">
       {{ backLink({
         "href": backLinkUrl,
-        "text": "Back"
+        "text": "Go back"
       }) }}
     </div>
 

--- a/app/pages/organisation/template.njk
+++ b/app/pages/organisation/template.njk
@@ -15,10 +15,13 @@
       }) }}
     </div>
   
-    <h1 data-test-id="org-page-title" class="nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3">{{ organisationName }}</h1>
-    <p data-test-id="org-page-description" class="nhsuk-heading-l nhsuk-u-font-size-22">These are the details for the organisation and its users.</p>
-
-    <h2 data-test-id="organisation-details-subheading">Organisation details</h2>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h1 data-test-id="org-page-title" class="nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-3">{{ organisationName }}</h1>
+        <p data-test-id="org-page-description" class="nhsuk-heading-l nhsuk-u-font-size-22">These are the details for the organisation and its users.</p>
+        <h2 data-test-id="organisation-details-subheading">Organisation details</h2>
+      </div>
+    </div>
 
     <dl class="nhsuk-summary-list nhsuk-u-padding-margin-5">
       <div class="nhsuk-summary-list__row">
@@ -72,8 +75,12 @@
       </div>
     </dl>
   
-    <h2>User accounts</h2>
-    <p>These are the user accounts for {{ organisationName }}.</p>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h2>User accounts</h2>
+        <p>These are the user accounts for {{ organisationName }}.</p>
+      </div>
+    </div>
 
     <div data-test-id="add-user-button">
       {{ actionLink({
@@ -82,7 +89,7 @@
       }) }}
     </div>
 
-    <div class="nhsuk-u-font-size-19">
+    <div data-test-id="users-table" class="nhsuk-u-font-size-19 even-table">
       {{ bcTable({
         columnInfo: [
           {
@@ -95,6 +102,7 @@
           {
             "data": "Email address"
           },
+          {},
           {}
         ],
         data: users,
@@ -102,8 +110,12 @@
       })}}
     </div>
 
-    <h2>Related organisations</h2>
-    <p>These are the organisations {{ organisationName }} can create orders for.</p>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h2>Related organisations</h2>
+        <p>These are the organisations {{ organisationName }} can create orders for.</p>
+      </div>
+    </div>
 
     <div data-test-id="add-organisation-button">
       {{ actionLink({
@@ -112,7 +124,7 @@
       }) }}
     </div>
 
-    <div id="related-org-table" class="nhsuk-u-font-size-19">
+    <div data-test-id="related-org-table" id="related-org-table" class="nhsuk-u-font-size-19 even-table">
       {{ bcTable({
         columnInfo: [
           {

--- a/app/pages/organisation/template.test.js
+++ b/app/pages/organisation/template.test.js
@@ -40,7 +40,7 @@ const mockData = {
     }, {
       tag: {
         dataTestId: 'account-disabled-tag-user2',
-        classes: 'bc-c-tag-outline nhsuk-u-font-size-16',
+        classes: 'bc-c-tag-outline nhsuk-u-font-size-14',
         text: 'ACCOUNT DISABLED',
       },
     }],

--- a/app/pages/organisation/ui.test.js
+++ b/app/pages/organisation/ui.test.js
@@ -134,7 +134,7 @@ test('should navigate to add related organisation page when add organisation but
     .expect(getLocation()).eql(`http://localhost:1234/admin/organisations/proxy/${orgId}`);
 });
 
-test('should navigate to view user page when user name is clicked', async (t) => {
+test('should navigate to view user page when manage is clicked', async (t) => {
   nock(identityApiLocalhost)
     .get(`/api/v1/Users/${usersData.users[0].userId}`)
     .reply(200, organisationDetails);
@@ -147,11 +147,26 @@ test('should navigate to view user page when user name is clicked', async (t) =>
 
   const orgId = organisationDetails.organisationId;
 
-  const user1Row = Selector('tr[data-test-id="table-row-0"]');
+  const user1Row = Selector('[data-test-id="users-table"] tr[data-test-id="table-row-0"]');
   const user1Name = user1Row.find('a');
 
   await t
     .expect(user1Name.exists).ok()
     .click(user1Name)
     .expect(getLocation()).eql(`http://localhost:1234/admin/organisations/${orgId}/${usersData.users[0].userId}`);
+});
+
+test('should navigate to remove organisation page when remove is clicked', async (t) => {
+  await pageSetup(t, true);
+  await t.navigateTo(pageUrl);
+
+  const orgId = organisationDetails.organisationId;
+
+  const user1Row = Selector('[data-test-id="related-org-table"] tr[data-test-id="table-row-0"]');
+  const user1Name = user1Row.find('a');
+
+  await t
+    .expect(user1Name.exists).ok()
+    .click(user1Name)
+    .expect(getLocation()).eql(`http://localhost:1234/admin/organisations/removeproxy/${orgId}/${relatedOrgs[0].organisationId}`);
 });

--- a/app/pages/viewuser/__snapshots__/template.test.js.snap
+++ b/app/pages/viewuser/__snapshots__/template.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`viewuser page the page should render 1`] = `
+"<main class=\\"nhsuk-main-wrapper\\" id=\\"maincontent\\" data-test-id=\\"main-content\\">
+        
+  <div class=\\"nhsuk-width-container\\" data-test-id=\\"view-user-page\\">
+    <div data-test-id=\\"go-back-link\\">
+      <div class=\\"nhsuk-back-link\\">
+  <a class=\\"nhsuk-back-link__link\\" href=\\"/organisations/org1\\">
+  <svg class=\\"nhsuk-icon nhsuk-icon__chevron-left\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" aria-hidden=\\"true\\">
+    <path d=\\"M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z\\"></path>
+  </svg>
+  Go back</a>
+</div>
+
+    </div>
+  
+    <div class=\\"nhsuk-grid-row\\">
+      <div class=\\"nhsuk-grid-column-two-thirds\\">
+        <h1 class=\\"nhsuk-u-margin-top-7\\" data-test-id=\\"view-user-page-title\\">John Smith details</h1>
+      </div>
+    </div>
+
+    <dl class=\\"nhsuk-summary-list nhsuk-u-padding-margin-5\\">
+      <div class=\\"nhsuk-summary-list__row\\">
+        <dt class=\\"nhsuk-summary-list__key\\">
+          Organisation name
+        </dt>
+        <dd class=\\"nhsuk-summary-list__value\\">
+          Greater Manchester CCG
+        </dd>
+      </div>
+      <div class=\\"nhsuk-summary-list__row\\">
+        <dt class=\\"nhsuk-summary-list__key\\">
+          Name
+        </dt>
+        <dd class=\\"nhsuk-summary-list__value\\">
+          John Smith
+        </dd>
+      </div>
+      <div class=\\"nhsuk-summary-list__row\\">
+        <dt class=\\"nhsuk-summary-list__key\\">
+          Contact details
+        </dt>
+        <dd class=\\"nhsuk-summary-list__value\\">
+          07777777777
+        </dd>
+      </div>
+      <div class=\\"nhsuk-summary-list__row\\">
+        <dt class=\\"nhsuk-summary-list__key\\">
+          Email address
+        </dt>
+        <dd class=\\"nhsuk-summary-list__value\\">
+          John@Smith.com
+        </dd>
+      </div>
+    </dl>
+
+    <div class=\\"nhsuk-grid-row\\">
+      <form method=\\"post\\" action=\\"/organisations/org1/user2/disable\\">
+        <input type=\\"hidden\\" name=\\"_csrf\\" value=\\"mockCsrfToken\\">
+        <div data-test-id=\\"change-account-status-button\\" class=\\"nhsuk-grid-column-one-quarter\\">
+          
+
+
+  
+    
+  
+
+
+
+
+<button class=\\"nhsuk-button nhsuk-u-margin-bottom-9\\" type=\\"submit\\">
+  Disable account
+</button>
+
+
+
+        </div>
+      </form>
+    </div>
+  <div>
+
+      </div></div></main>"
+`;

--- a/app/pages/viewuser/template.njk
+++ b/app/pages/viewuser/template.njk
@@ -8,19 +8,50 @@
     <div data-test-id="go-back-link">
       {{ backLink({
         "href": backLinkHref,
-        "text": "Back"
+        "text": "Go back"
       }) }}
     </div>
   
-    <h1 data-test-id="view-user-page-title" class="">{{ userName }} {{ title }}</h1>
-    <h2 data-test-id="organisation-name-heading" class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ orgHeading }}</h2>
-    <div data-test-id="organisation-name" class="nhsuk-u-font-size-19 nhsuk-u-margin-bottom-5">{{ organisationName }}</div>
-    <h2 data-test-id="user-name-heading" class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ nameHeading }}</h2>
-    <div data-test-id="user-name" class="nhsuk-u-font-size-19 nhsuk-u-margin-bottom-5">{{ userName }}</div>
-    <h2 data-test-id="user-contact-details-heading" class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ phoneNumberHeading }}</h2>
-    <div data-test-id="user-contact-details" class="nhsuk-u-font-size-19 nhsuk-u-margin-bottom-5">{{ phoneNumber }}</div>
-    <h2 data-test-id="user-email-heading" class="nhsuk-heading-s nhsuk-u-margin-bottom-2">{{ emailAddressHeading }}</h2>
-    <div data-test-id="user-email" class="nhsuk-u-font-size-19 nhsuk-u-margin-bottom-7">{{ emailAddress }}</div>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <h1 class="nhsuk-u-margin-top-7" data-test-id="view-user-page-title" class="">{{ userName }} {{ title }}</h1>
+      </div>
+    </div>
+
+    <dl class="nhsuk-summary-list nhsuk-u-padding-margin-5">
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          {{ orgHeading }}
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          {{ organisationName }}
+        </dd>
+      </div>
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          {{ nameHeading }}
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          {{ userName }}
+        </dd>
+      </div>
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          {{ phoneNumberHeading }}
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          {{ phoneNumber }}
+        </dd>
+      </div>
+      <div class="nhsuk-summary-list__row">
+        <dt class="nhsuk-summary-list__key">
+          {{ emailAddressHeading }}
+        </dt>
+        <dd class="nhsuk-summary-list__value">
+          {{ emailAddress }}
+        </dd>
+      </div>
+    </dl>
 
     <div class="nhsuk-grid-row">
       <form method="post" action="{{ changeAccountStatusFormAction }}">

--- a/app/pages/viewuser/template.test.js
+++ b/app/pages/viewuser/template.test.js
@@ -1,4 +1,4 @@
-import { componentTester } from '../../test-utils/componentTester';
+import { componentTester, snapshotTest } from '../../test-utils/componentTester';
 import manifest from './manifest.json';
 
 const setup = {
@@ -26,64 +26,19 @@ const mockContext = {
 };
 
 describe('viewuser page', () => {
+  it('the page should render', componentTester(setup, (harness) => {
+    harness.request(mockContext, ($) => {
+      const snapshot = snapshotTest($, '[data-test-id="main-content"]');
+      expect(snapshot).toMatchSnapshot();
+    });
+  }));
+
   it('should render a backLink to the organisation page', componentTester(setup, (harness) => {
     harness.request(mockContext, ($) => {
       const homepageBackLink = $('[data-test-id="go-back-link"]');
       expect(homepageBackLink.length).toEqual(1);
-      expect(homepageBackLink.text().trim()).toEqual('Back');
+      expect(homepageBackLink.text().trim()).toEqual('Go back');
       expect($(homepageBackLink).find('a').attr('href')).toEqual(mockContext.backLinkHref);
-    });
-  }));
-
-  it('should render a title', componentTester(setup, (harness) => {
-    harness.request(mockContext, ($) => {
-      const title = $('h1[data-test-id="view-user-page-title"]');
-      expect(title.length).toEqual(1);
-      expect(title.text().trim()).toEqual(`${mockContext.userName} ${mockContext.title}`);
-    });
-  }));
-
-  it('should render organisation name', componentTester(setup, (harness) => {
-    harness.request(mockContext, ($) => {
-      const heading = $('h2[data-test-id="organisation-name-heading"]');
-      const orgName = $('div[data-test-id="organisation-name"]');
-      expect(heading.length).toEqual(1);
-      expect(heading.text().trim()).toEqual(mockContext.orgHeading);
-      expect(orgName.length).toEqual(1);
-      expect(orgName.text().trim()).toEqual(mockContext.organisationName);
-    });
-  }));
-
-  it('should render user name', componentTester(setup, (harness) => {
-    harness.request(mockContext, ($) => {
-      const heading = $('h2[data-test-id="user-name-heading"]');
-      const userName = $('div[data-test-id="user-name"]');
-      expect(heading.length).toEqual(1);
-      expect(heading.text().trim()).toEqual(mockContext.nameHeading);
-      expect(userName.length).toEqual(1);
-      expect(userName.text().trim()).toEqual(mockContext.userName);
-    });
-  }));
-
-  it('should render contact details', componentTester(setup, (harness) => {
-    harness.request(mockContext, ($) => {
-      const heading = $('h2[data-test-id="user-contact-details-heading"]');
-      const contactDetails = $('div[data-test-id="user-contact-details"]');
-      expect(heading.length).toEqual(1);
-      expect(heading.text().trim()).toEqual(mockContext.phoneNumberHeading);
-      expect(contactDetails.length).toEqual(1);
-      expect(contactDetails.text().trim()).toEqual(mockContext.phoneNumber);
-    });
-  }));
-
-  it('should render email address', componentTester(setup, (harness) => {
-    harness.request(mockContext, ($) => {
-      const heading = $('h2[data-test-id="user-email-heading"]');
-      const emailAddress = $('div[data-test-id="user-email"]');
-      expect(heading.length).toEqual(1);
-      expect(heading.text().trim()).toEqual(mockContext.emailAddressHeading);
-      expect(emailAddress.length).toEqual(1);
-      expect(emailAddress.text().trim()).toEqual(mockContext.emailAddress);
     });
   }));
 

--- a/app/pages/viewuser/ui.test.js
+++ b/app/pages/viewuser/ui.test.js
@@ -99,62 +99,6 @@ test('should render the title', async (t) => {
     .expect(await extractInnerText(title)).eql(`${userData.name} ${content.title}`);
 });
 
-test('should render organisation name', async (t) => {
-  await pageSetup(t, true);
-  await t.navigateTo(pageUrl);
-
-  const orgNameHeading = Selector('h2[data-test-id="organisation-name-heading"]');
-  const orgName = Selector('div[data-test-id="organisation-name"]');
-
-  await t
-    .expect(orgNameHeading.exists).ok()
-    .expect(await extractInnerText(orgNameHeading)).eql(content.orgHeading)
-    .expect(orgName.exists).ok()
-    .expect(await extractInnerText(orgName)).eql(organisationData.name);
-});
-
-test('should render user name', async (t) => {
-  await pageSetup(t, true);
-  await t.navigateTo(pageUrl);
-
-  const userNameHeading = Selector('h2[data-test-id="user-name-heading"]');
-  const userName = Selector('div[data-test-id="user-name"]');
-
-  await t
-    .expect(userNameHeading.exists).ok()
-    .expect(await extractInnerText(userNameHeading)).eql(content.nameHeading)
-    .expect(userName.exists).ok()
-    .expect(await extractInnerText(userName)).eql(userData.name);
-});
-
-test('should render contact details', async (t) => {
-  await pageSetup(t, true);
-  await t.navigateTo(pageUrl);
-
-  const contactDetailsHeading = Selector('h2[data-test-id="user-contact-details-heading"]');
-  const contactDetails = Selector('div[data-test-id="user-contact-details"]');
-
-  await t
-    .expect(contactDetailsHeading.exists).ok()
-    .expect(await extractInnerText(contactDetailsHeading)).eql(content.phoneNumberHeading)
-    .expect(contactDetailsHeading.exists).ok()
-    .expect(await extractInnerText(contactDetails)).eql(userData.phoneNumber);
-});
-
-test('should render email address', async (t) => {
-  await pageSetup(t, true);
-  await t.navigateTo(pageUrl);
-
-  const emailHeading = Selector('h2[data-test-id="user-email-heading"]');
-  const email = Selector('div[data-test-id="user-email"]');
-
-  await t
-    .expect(emailHeading.exists).ok()
-    .expect(await extractInnerText(emailHeading)).eql(content.emailAddressHeading)
-    .expect(email.exists).ok()
-    .expect(await extractInnerText(email)).eql(userData.emailAddress);
-});
-
 test('should render change account status button', async (t) => {
   await pageSetup(t, true);
   await t.navigateTo(pageUrl);

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -8,3 +8,28 @@
 .float-right {
   float: right;
 }
+
+.even-table {
+  .bc-c-data-text {
+    margin: 0;
+  }
+
+  th,
+  td {
+    padding: 8px !important;
+    vertical-align: middle;
+
+    &:first-child {
+      padding-left: 0 !important;
+    }
+
+    &:last-child {
+      padding-right: 0 !important;
+    }
+  }
+
+  th {
+    padding-bottom: 0 !important;
+    padding-top: 0 !important;
+  }
+}


### PR DESCRIPTION
Story: [AB#14686](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/14686)
Task: [AB#14689](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/14689)


I added some snapshots and refactored the personal details page into a definition list:
![personal-details](https://user-images.githubusercontent.com/78418803/118268844-d45ee080-b4b5-11eb-9be1-fd52617679cd.png)
I had to normalise the table styling to make it look right, if you look at the table on the right, the spacing is uneven:
![table-compare](https://user-images.githubusercontent.com/78418803/118268848-d4f77700-b4b5-11eb-8fb3-19477b390e19.png)
And the manage button is added:
![manage-button](https://user-images.githubusercontent.com/78418803/118268849-d5900d80-b4b5-11eb-907e-e44430d00c04.png)
